### PR TITLE
Slick-Sliderのレイアウト修正

### DIFF
--- a/app/assets/stylesheets/top_contents.scss
+++ b/app/assets/stylesheets/top_contents.scss
@@ -1,3 +1,10 @@
+.slider {
+  display: none;
+}
+.slider.slick-initialized {
+  display: block;
+}
+
 .header-tags {
   display: none;
   position: absolute;


### PR DESCRIPTION
# WHAT
Slick-Slider（プラグイン）利用に伴い、トップ画面表示時にレイアウトが崩れてしまう現象を解消する

# WHY
ユーザの視認性を高めるため